### PR TITLE
Derive `Clone` on `piano_roll_window::ChannelSettings`

### DIFF
--- a/ui-common/src/piano_roll_window.rs
+++ b/ui-common/src/piano_roll_window.rs
@@ -70,6 +70,7 @@ impl ChannelSlice {
     }
 }
 
+#[derive(Clone)]
 pub struct ChannelSettings {
     pub colors: Vec<Color>,
     pub hidden: bool


### PR DESCRIPTION
This is a super simple PR but it makes working with the piano roll window externally much easier. Otherwise I'd need to use a newtype with a custom `Clone` impl to work with the settings object.