### PR TITLE
Core: add `version()` getter

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,3 +16,7 @@ pub mod opcode_info;
 pub mod palettes;
 pub mod ppu;
 pub mod unofficial_opcodes;
+
+pub fn version() -> &'static str {
+    option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
+}


### PR DESCRIPTION
Another simple PR. This just adds a facility to get the Cargo version string from the core. This could also be utilized in the other crates to unify the version numbers provided to the user.